### PR TITLE
Fixes build requires argument error

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Installation requires following steps:
 
 2. `cd greeter && mkdir build`
 
-3. `docker build -t "lightdm-webkit-greeter"`
+3. `docker build -t "lightdm-webkit-greeter" .`
 
 4. `docker run --rm -v $PWD/build:/root/build --name "lightdm-webkit-greeter" lightdm-webkit-greeter`
 


### PR DESCRIPTION
Missing a dot at the end of the command in step 3 indicating to build from the Dockerfile in the working directory.